### PR TITLE
🎨 Palette: Add aria_labels to icon-only action buttons

### DIFF
--- a/app/components/ui.py
+++ b/app/components/ui.py
@@ -4,7 +4,7 @@ from monsterui.all import Button, ButtonT, Form, UkIcon
 
 def IconLinkButton(icon_name: str, href: str, title: str, cls=ButtonT.icon):
     return A(
-        Button(UkIcon(icon_name, height=15, width=15), cls=cls),
+        Button(UkIcon(icon_name, height=15, width=15), cls=cls, aria_label=title),
         href=href,
         title=title,
     )
@@ -22,6 +22,7 @@ def IconPostButton(
         type=button_type,
         title=title,
         cls=cls,
+        aria_label=title,
     )
     if action is None:
         return button

--- a/app/components/ui.py
+++ b/app/components/ui.py
@@ -4,9 +4,11 @@ from monsterui.all import Button, ButtonT, Form, UkIcon
 
 def IconLinkButton(icon_name: str, href: str, title: str, cls=ButtonT.icon):
     return A(
-        Button(UkIcon(icon_name, height=15, width=15), cls=cls, aria_label=title),
+        UkIcon(icon_name, height=15, width=15),
         href=href,
         title=title,
+        cls=cls,
+        aria_label=title,
     )
 
 


### PR DESCRIPTION
💡 **What:** Added `aria_label` to icon-only buttons (`ViewAction`, `EditAction`, `DeleteAction`, etc.) using the `title` parameter in `app/components/ui.py`.
🎯 **Why:** To improve accessibility for screen reader users so they can understand the actions associated with the icon-only buttons in the BIM compliance workflow.
📸 **Before/After:** No visual changes since `aria_label` is an accessibility attribute.
♿ **Accessibility:** Screen readers will now announce "View", "Edit", "Delete", etc. instead of just "button".

---
*PR created automatically by Jules for task [10539245819491136923](https://jules.google.com/task/10539245819491136923) started by @osama-ata*